### PR TITLE
Sw/use appmap to create openapi doc

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,173 @@
-.env_sample
+# Development options
+
+# App core values
+APP_DOMAIN="localhost:3000"
+APP_PROTOCOL="http://"
+FOREM_OWNER_SECRET="secret"
+
+# Community Related Variables
+COMMUNITY_NAME="DEV(local)"
+
+# Email related variables
+DEFAULT_EMAIL="yo@dev.to"
+
+# Service timeout length
+RACK_TIMEOUT_WAIT_TIMEOUT=100_000
+RACK_TIMEOUT_SERVICE_TIMEOUT=100_000
+
+# Heroku release slug used to bust caches on deploys
+HEROKU_RELEASE_CREATED_AT=""
+HEROKU_SLUG_COMMIT=""
+
+# Redis caching storage
+REDIS_URL="redis://localhost:$REDIS_PORT"
+
+# Redis sessions storage
+REDIS_SESSIONS_URL="redis://localhost:$REDIS_PORT"
+SESSION_KEY="_Dev_Community_Session"
+# two weeks in seconds
+SESSION_EXPIRY_SECONDS=1209600
+
+# Redis Sidekiq storage
+REDIS_SIDEKIQ_URL="redis://localhost:$REDIS_PORT"
+
+# Redis Devices/Rpush storage
+REDIS_RPUSH_URL="redis://localhost:$REDIS_PORT"
+
+# OpenResty
+OPENRESTY_URL=""
+
+# SSL config
+FORCE_SSL_IN_RAILS="not applicable in dev"
+
+# Postgres DB
+# Used when creating a db instance `rails db:create`
+DATABASE_NAME="Forem_development"
+# This takes precedence over `DATABASE_NAME` if they don't match
+DATABASE_URL="postgresql://localhost:5432/Forem_development"
+# Specifies the number of Puma threads
+RAILS_MAX_THREADS=5
+# Specifies the number of `workers` to boot in clustered mode.
+WEB_CONCURRENCY=2
+# The number of concurrent connections to Postgres. If unset the value of RAILS_MAX_THREADS will be used in it's place.
+DATABASE_POOL_SIZE=5
+DATABASE_NAME_TEST=Forem_test
+# Differentiate test db from dev db. Test DB is wiped on each test run.
+DATABASE_URL_TEST="postgresql://localhost:$DATABASE_PORT_TEST/Forem_test"
+
+# Rails
+# Set to 'production' when deploying for security and performance.
+RAILS_ENV="test"
+
+# Node
+# Set to 'production' when deploying for security and performance.
+NODE_ENV="development"
+
+################################################
+######### Optional 3rd Party Services ##########
+################################################
+
+# Honeybadger for error tracking
+# (https://docs.honeybadger.io/lib/ruby/getting-started/introduction.html)
+HONEYBADGER_API_KEY="Optional"
+HONEYBADGER_JS_API_KEY="Optional"
+
+# AWS for images storages
+AWS_ID=
+AWS_SECRET=
+AWS_BUCKET_NAME=
+AWS_UPLOAD_REGION=
+
+# AWS for video storage
+AWS_S3_INPUT_BUCKET="Optional"
+AWS_S3_VIDEO_ID="Optional"
+AWS_S3_VIDEO_KEY="Optional"
+
+# Buffer for sending to buffer
+# This is legacy, as Buffer no longer supports this functionality for NEW accounts.
+# DEV is still using this for now.
+# (https://buffer.com/developers/api)
+BUFFER_ACCESS_TOKEN="Optional"
+BUFFER_FACEBOOK_ID="Optional"
+BUFFER_LINKEDIN_ID="Optional"
+BUFFER_PROFILE_ID=0
+BUFFER_TWITTER_ID="Optional"
+BUFFER_LISTINGS_PROFILE="Optional"
+
+# Cloudinary for image resizing and cache??
+# (https://cloudinary.com/documentation/rails_integration)
+CLOUDINARY_API_KEY=
+CLOUDINARY_API_SECRET=
+CLOUDINARY_CLOUD_NAME=
+CLOUDINARY_SECURE=true
+
+# HTML/CSS to Image for generating social preview images
+# (https://docs.htmlcsstoimage.com/example-code/ruby)
+HCTI_API_USER_ID="Optional"
+HCTI_API_KEY="Optional"
+
+# Fastly for edge caching
+# (https://docs.fastly.com/api/)
+FASTLY_API_KEY=""
+FASTLY_SERVICE_ID=""
+
+# Honeycomb for monitoring and observability
+# (https://www.honeycomb.io/)
+HONEYCOMB_API_KEY=""
+
+# Google analytics 3/Universal Analytics
+# (https://developers.google.com/analytics/devguides/reporting/core/v4)
+# When blank don't render Google Analytics.
+GA_TRACKING_ID=""
+
+# Google analytics 4/Tag Manager
+# (https://developers.google.com/analytics/devguides/reporting/data/v1)
+# When blank don't render Google Analytics 4.
+GA_ANALYTICS_4_ID=""
+
+# Mailchimp for mails
+# (https://mailchimp.com/developer/)
+MAILCHIMP_API_KEY="Optional-valid"
+
+# Google recaptcha (Optional)
+# (https://developers.google.com/recaptcha/intro)
+RECAPTCHA_SECRET=
+RECAPTCHA_SITE=
+
+# Slack for customer alerts
+# (https://api.slack.com/)
+SLACK_CHANNEL=""
+SLACK_DEPLOY_CHANNEL=""
+SLACK_WEBHOOK_URL=""
+
+# For video calling in DEV Connect
+# (https://www.twilio.com/docs/video)
+TWILIO_ACCOUNT_SID="Optional"
+TWILIO_VIDEO_API_KEY="Optional"
+TWILIO_VIDEO_API_SECRET="Optional"
+
+# For Twitch live stream integration
+# (https://dev.twitch.tv/docs)
+TWITCH_CLIENT_ID="Optional"
+TWITCH_CLIENT_SECRET="Optional"
+TWITCH_WEBHOOK_SECRET="Optional"
+
+# For calling the Stack Exchange API
+# (https://api.stackexchange.com/docs)
+STACK_EXCHANGE_APP_KEY=""
+
+# For calling the Github API
+# (https://docs.github.com/)
+GITHUB_KEY="Optional"
+GITHUB_SECRET="Optional"
+
+# For SMTP configuration
+SMTP_ADDRESS=
+SMTP_PORT=
+SMTP_DOMAIN=
+SMTP_USER_NAME=
+SMTP_PASSWORD=
+SMTP_AUTHENTICATION=
+
+# Disable simplecov coverage testing when running rspec locally
+COVERAGE="false"

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,10 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
-# Ignore bundler config.
+# Ignore bundler config, bundle and cache.
 /.bundle
 vendor/bundle
+vendor/cache
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,6 +8,7 @@
     "ms-vsliveshare.vsliveshare-pack",
     "42crunch.vscode-openapi",
     "philosowaffle.openapi-designer",
-    "silvenon.mdx"
+    "silvenon.mdx",
+    "appland.appmap",
   ]
 }

--- a/app/models/async_info.rb
+++ b/app/models/async_info.rb
@@ -18,7 +18,7 @@ class AsyncInfo
   # @todo The given feed_style_prefernce could be extracted to the user decorator.  We would need to
   #       account for a nil current user in our view logic.
   def self.to_hash(user:, context:)
-    new(user: user, context: context).to_hash
+    new(user: user, context: context).to_h
   end
 
   def initialize(user:, context:)
@@ -28,7 +28,7 @@ class AsyncInfo
 
   attr_reader :user, :context
 
-  def to_hash
+  def to_h
     {
       id: user.id,
       name: user.name,

--- a/app/models/reaction_category.rb
+++ b/app/models/reaction_category.rb
@@ -2,26 +2,26 @@
 class ReactionCategory
   class << self
     def [](slug)
-      hash[slug.to_sym]
+      to_h[slug.to_sym]
     end
 
     def all_slugs
-      list.map(&:slug)
+      to_a.map(&:slug)
     end
 
     def negative_privileged
-      list.filter_map { |category| category.slug if category.privileged? && category.negative? }
+      to_a.filter_map { |category| category.slug if category.privileged? && category.negative? }
     end
 
     def public
-      list.sort_by(&:position).filter_map { |category| category.slug if category.visible_to_public? }
+      to_a.sort_by(&:position).filter_map { |category| category.slug if category.visible_to_public? }
     end
 
     def privileged
-      list.filter_map { |category| category.slug if category.privileged? }
+      to_a.filter_map { |category| category.slug if category.privileged? }
     end
 
-    def list
+    def to_a
       @list ||= to_h.values
     end
 

--- a/app/models/reaction_category.rb
+++ b/app/models/reaction_category.rb
@@ -22,10 +22,10 @@ class ReactionCategory
     end
 
     def list
-      @list ||= hash.values
+      @list ||= to_h.values
     end
 
-    def hash
+    def to_h
       @hash ||= REACTION_CATEGORY_LIST.each_pair.to_h do |slug, category_or_attributes|
         as_category = if category_or_attributes.is_a?(ReactionCategory)
                         category_or_attributes

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -266,4 +266,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.example_status_persistence_file_path = "tmp/rspec_example_status.txt"
 end

--- a/spec/requests/api/v1/docs/articles_spec.rb
+++ b/spec/requests/api/v1/docs/articles_spec.rb
@@ -5,7 +5,7 @@ require "swagger_helper"
 # rubocop:disable RSpec/VariableName
 # rubocop:disable Layout/LineLength
 
-RSpec.describe "Api::V1::Docs::Articles" do
+RSpec.describe "Api::V1::Docs::Articles", appmap: false do
   let(:organization) { create(:organization) } # not used by every spec but lower times overall
   let(:tag) { create(:tag, :with_colors, name: "discuss") }
   let(:article) { create(:article, featured: true, tags: "discuss", published: true) }

--- a/spec/requests/api/v1/docs/display_ads_spec.rb
+++ b/spec/requests/api/v1/docs/display_ads_spec.rb
@@ -4,7 +4,7 @@ require "swagger_helper"
 # rubocop:disable RSpec/EmptyExampleGroup
 # rubocop:disable RSpec/VariableName
 
-RSpec.describe "api/v1/display_ads" do
+RSpec.describe "api/v1/display_ads", appmap: false do
   let(:Accept) { "application/vnd.forem.api-v1+json" }
   let(:api_secret) { create(:api_secret) }
   let(:display_ad) { create(:display_ad) }

--- a/spec/requests/api/v1/docs/followers_spec.rb
+++ b/spec/requests/api/v1/docs/followers_spec.rb
@@ -4,7 +4,7 @@ require "swagger_helper"
 # rubocop:disable RSpec/EmptyExampleGroup
 # rubocop:disable RSpec/VariableName
 
-RSpec.describe "Api::V1::Docs::Followers" do
+RSpec.describe "Api::V1::Docs::Followers", appmap: false do
   let(:Accept) { "application/vnd.forem.api-v1+json" }
   let(:api_secret) { create(:api_secret) }
   let(:user) { api_secret.user }

--- a/spec/requests/api/v1/docs/podcast_episodes_spec.rb
+++ b/spec/requests/api/v1/docs/podcast_episodes_spec.rb
@@ -4,7 +4,7 @@ require "swagger_helper"
 # rubocop:disable RSpec/EmptyExampleGroup
 # rubocop:disable RSpec/VariableName
 
-RSpec.describe "Api::V1::Docs::PodcastEpisodes" do
+RSpec.describe "Api::V1::Docs::PodcastEpisodes", appmap: false do
   let(:Accept) { "application/vnd.forem.api-v1+json" }
   let!(:podcast) { create(:podcast, slug: "codenewbie") }
 

--- a/spec/requests/api/v1/docs/profile_images_spec.rb
+++ b/spec/requests/api/v1/docs/profile_images_spec.rb
@@ -4,7 +4,7 @@ require "swagger_helper"
 # rubocop:disable RSpec/EmptyExampleGroup
 # rubocop:disable RSpec/VariableName
 
-RSpec.describe "Api::V1::Docs::ProfileImages" do
+RSpec.describe "Api::V1::Docs::ProfileImages", appmap: false do
   let(:Accept) { "application/vnd.forem.api-v1+json" }
   let(:api_secret) { create(:api_secret) }
   let(:user) { api_secret.user }

--- a/spec/requests/api/v1/docs/reactions_spec.rb
+++ b/spec/requests/api/v1/docs/reactions_spec.rb
@@ -4,7 +4,7 @@ require "swagger_helper"
 # rubocop:disable RSpec/EmptyExampleGroup
 # rubocop:disable RSpec/VariableName
 
-RSpec.describe "api/v1/reactions" do
+RSpec.describe "api/v1/reactions", appmap: false do
   let(:Accept) { "application/vnd.forem.api-v1+json" }
   let(:api_secret) { create(:api_secret) }
   let(:category) { "like" }

--- a/spec/requests/api/v1/docs/readinglist_spec.rb
+++ b/spec/requests/api/v1/docs/readinglist_spec.rb
@@ -4,7 +4,7 @@ require "swagger_helper"
 # rubocop:disable RSpec/EmptyExampleGroup
 # rubocop:disable RSpec/VariableName
 
-RSpec.describe "Api::V1::Docs::Readinglist" do
+RSpec.describe "Api::V1::Docs::Readinglist", appmap: false do
   let(:api_secret) { create(:api_secret) }
   let(:user) { api_secret.user }
   let(:readinglist) { create_list(:reading_reaction, 3, user: user) }

--- a/spec/requests/api/v1/docs/users_spec.rb
+++ b/spec/requests/api/v1/docs/users_spec.rb
@@ -4,7 +4,7 @@ require "swagger_helper"
 # rubocop:disable RSpec/EmptyExampleGroup
 # rubocop:disable RSpec/VariableName
 
-RSpec.describe "Api::V1::Docs::Users" do
+RSpec.describe "Api::V1::Docs::Users", appmap: false do
   let(:Accept) { "application/vnd.forem.api-v1+json" }
   let(:api_secret) { create(:api_secret) }
   let(:user) { api_secret.user }


### PR DESCRIPTION
Updates for making AppMaps of Forem.

I'm running `rspec spec/requests` and so far they are all working except for `spec/requests/api/v1/docs` (https://github.com/getappmap/appmap-ruby/issues/309)

PS Run rspec with `--backtrace` option to get full stack traces of errors.

Try:

```
$ RAILS_ENV=test bundle exec rspec --backtrace \
  --exclude-pattern "spec/requests/api/v1/docs/*_spec.rb" \
  ./spec/requests/ spec/system                                      
```